### PR TITLE
🔨 Add branch pruning during git fetch operation

### DIFF
--- a/scripts/cleanup-branches.sh
+++ b/scripts/cleanup-branches.sh
@@ -57,9 +57,9 @@ check_uncommitted_changes() {
 update_main_branch() {
     local current_branch=$(git rev-parse --abbrev-ref HEAD)
     
-    # First fetch all changes
-    log "⬇️" "Fetching latest changes"
-    if ! execute "git fetch origin"; then
+    # First fetch all changes and prune stale remote references
+    log "⬇️" "Fetching latest changes and pruning stale references"
+    if ! execute "git fetch origin --prune"; then
         return 1
     fi
     


### PR DESCRIPTION
Enhances the update_main_branch function to automatically prune stale remote references during fetch operations. This helps keep the local repository clean by removing references to deleted remote branches, reducing confusion and improving repository maintenance.